### PR TITLE
Add hires fix for Stable Diffusion

### DIFF
--- a/src/ImageGenerator.cpp
+++ b/src/ImageGenerator.cpp
@@ -60,6 +60,11 @@ AFuture<ImageGenerator::GalleryImage> ImageGenerator::generate(AString descripti
                         .cfg_scale = std::uniform_real_distribution<>(1.0, 5.0)(ge),
                         .width = std::uniform_int_distribution<>(768, 1400)(ge),
                         .height = std::uniform_int_distribution<>(768, 1400)(ge),
+                        .enable_hr = true,
+                        .hr_scale = 1.5,
+                        .hr_upscaler = "Latent",
+                        .hr_second_pass_steps = 10,
+                        .denoising_strength = 0.7,
                     });
                 } catch (const AException& e) {
                     ALogger::err(LOG_TAG) << "Stable diffusion failed:: " << e;

--- a/src/StableDiffusionClient.cpp
+++ b/src/StableDiffusionClient.cpp
@@ -28,7 +28,7 @@ AJSON_FIELDS(StableDiffusionClient::Txt2ImgRequest,
              AJSON_FIELDS_ENTRY(height)
              AJSON_FIELDS_ENTRY(send_images)
              AJSON_FIELDS_ENTRY(override_settings)
-             AJSON_FIELDS_ENTRY(save_images))
+             AJSON_FIELDS_ENTRY(save_images)
              AJSON_FIELDS_ENTRY(enable_hr)
              AJSON_FIELDS_ENTRY(hr_scale)
              AJSON_FIELDS_ENTRY(hr_upscaler)

--- a/src/StableDiffusionClient.cpp
+++ b/src/StableDiffusionClient.cpp
@@ -29,6 +29,11 @@ AJSON_FIELDS(StableDiffusionClient::Txt2ImgRequest,
              AJSON_FIELDS_ENTRY(send_images)
              AJSON_FIELDS_ENTRY(override_settings)
              AJSON_FIELDS_ENTRY(save_images))
+             AJSON_FIELDS_ENTRY(enable_hr)
+             AJSON_FIELDS_ENTRY(hr_scale)
+             AJSON_FIELDS_ENTRY(hr_upscaler)
+             AJSON_FIELDS_ENTRY(hr_second_pass_steps)
+             AJSON_FIELDS_ENTRY(denoising_strength))
 
 AFuture<StableDiffusionClient::Txt2ImgResponse> StableDiffusionClient::txt2img(const Txt2ImgRequest& request) {
     auto query = AJson::toString(aui::to_json(request));

--- a/src/StableDiffusionClient.h
+++ b/src/StableDiffusionClient.h
@@ -32,6 +32,11 @@ struct StableDiffusionClient {
         int64_t height = 512;
         bool send_images = true;
         bool save_images = false;
+        bool enable_hr = false;
+        double hr_scale = 2.0;
+        AString hr_upscaler = "Latent";
+        int64_t hr_second_pass_steps = 0;
+        double denoising_strength = 0.7;
     };
 
     struct Txt2ImgResponse {


### PR DESCRIPTION
Introduced Hires fix element for the Stable Diffusion client.
Default settings are 10 steps of latent upscale by 1.5x