### PR TITLE
Unload SD checkpoint after image generation

### DIFF
--- a/src/ImageGenerator.cpp
+++ b/src/ImageGenerator.cpp
@@ -76,6 +76,13 @@ AFuture<ImageGenerator::GalleryImage> ImageGenerator::generate(AString descripti
                 }
                 auto lastImage = response.images[0];
                 PngImageLoader::save(AFileOutputStream{ "image_generator_tmp.png" }, *lastImage);
+                //Unload SD checkpoint after generation
+                try {
+                    co_await mSdClient.unloadCheckpoint();
+                    ALogger::info(LOG_TAG) << "Checkpoint unloaded from VRAM";
+                } catch (const AException& e) {
+                    ALogger::warn(LOG_TAG) << "Failed to unload checkpoint: " << e;
+                }
 
                 ALogger::info(LOG_TAG) << "Assessing image...";
                 auto assessment = co_await assessImage(*lastImage, descriptionWithAppearance);

--- a/src/StableDiffusionClient.cpp
+++ b/src/StableDiffusionClient.cpp
@@ -60,3 +60,20 @@ AFuture<StableDiffusionClient::Txt2ImgResponse> StableDiffusionClient::txt2img(c
     res.info = response["info"];
     co_return res;
 }
+
+AFuture<> StableDiffusionClient::unloadCheckpoint() {
+    ALOG_TRACE(LOG_TAG) << "unloadCheckpoint";
+
+    AVector<AString> headers = {"Content-Type: application/json"};
+    if (!endpoint.bearerKey.empty()) {
+        headers << "Authorization: Bearer {}"_format(endpoint.bearerKey);
+    }
+
+    co_await ACurl::Builder(endpoint.baseUrl + "sdapi/v1/unload-checkpoint")
+        .withMethod(ACurl::Method::HTTP_POST)
+        .withHeaders(std::move(headers))
+        .withTimeout(config::REQUEST_TIMEOUT)
+        .runAsync();
+
+    co_return;
+}

--- a/src/StableDiffusionClient.h
+++ b/src/StableDiffusionClient.h
@@ -45,4 +45,5 @@ struct StableDiffusionClient {
     };
 
     AFuture<Txt2ImgResponse> txt2img(const Txt2ImgRequest& request);
+    AFuture<> unloadCheckpoint();
 };


### PR DESCRIPTION
Well, it's better than --medvram and constantly keeping the checkpoint in memory. Especially on video cards with small VRAM. 