### PR TITLE
Prometheus: add proactivity tracking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
 #    command:
 #      - '--config.file=/etc/prometheus/prometheus.yml'
 #      - '--storage.tsdb.path=/prometheus'
+##      - '--web.enable-admin-api'
 #    extra_hosts:
 #      - "host.docker.internal:host-gateway"
 #

--- a/grafana/dashboards/main.json
+++ b/grafana/dashboards/main.json
@@ -3,7 +3,7 @@
   "kind": "Dashboard",
   "metadata": {
     "name": "adnzl7w",
-    "generation": 1,
+    "generation": 140,
     "creationTimestamp": "2026-05-14T10:05:54Z",
     "labels": {},
     "annotations": {}
@@ -17,10 +17,7 @@
             "kind": "DataQuery",
             "group": "grafana",
             "version": "v0",
-            "spec": {},
-            "labels": {
-              "grafana.app/export-label": "grafana-1"
-            }
+            "spec": {}
           },
           "enable": true,
           "hide": true,
@@ -33,12 +30,12 @@
     "cursorSync": "Off",
     "editable": true,
     "elements": {
-      "panel-3": {
+      "panel-10": {
         "kind": "Panel",
         "spec": {
-          "id": 3,
-          "title": "Топ дрочеров куни",
-          "description": "",
+          "id": 10,
+          "title": "Абсолютный размер контекста ($model)",
+          "description": "Размер запроса в LLM. По достижению DIARY_TOKEN_COUNT_TRIGGER он сбрасывается в дневник и начинает с чистого листа.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -52,244 +49,12 @@
                       "group": "prometheus",
                       "version": "v0",
                       "spec": {
-                        "editorMode": "builder",
+                        "editorMode": "code",
                         "exemplar": false,
-                        "expr": "sum by(chat) (llm_usage_input)",
-                        "format": "table",
-                        "instant": true,
-                        "legendFormat": "chat",
-                        "range": false
-                      },
-                      "labels": {
-                        "grafana.app/export-label": "prometheus-1"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "table",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "cellHeight": "sm",
-                "frameIndex": 7,
-                "showHeader": true,
-                "sortBy": [
-                  {
-                    "desc": true,
-                    "displayName": "Value"
-                  }
-                ]
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "custom": {
-                    "align": "auto",
-                    "cellOptions": {
-                      "type": "auto"
-                    },
-                    "footer": {
-                      "reducers": []
-                    },
-                    "inspect": false
-                  }
-                },
-                "overrides": [
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "scope": "series",
-                      "options": "Time"
-                    },
-                    "properties": [
-                      {
-                        "id": "custom.hideFrom.viz",
-                        "value": true
-                      }
-                    ]
-                  },
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "scope": "series",
-                      "options": "function"
-                    },
-                    "properties": [
-                      {
-                        "id": "custom.hideFrom.viz",
-                        "value": false
-                      }
-                    ]
-                  },
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "scope": "series",
-                      "options": "model"
-                    },
-                    "properties": [
-                      {
-                        "id": "custom.hideFrom.viz",
-                        "value": false
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          }
-        }
-      },
-      "panel-5": {
-        "kind": "Panel",
-        "spec": {
-          "id": 5,
-          "title": "Логи",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "spec": {
-                        "editorMode": "builder",
-                        "expr": "llm_usage_input",
-                        "format": "table",
-                        "instant": false,
-                        "legendFormat": "__auto",
+                        "expr": "llm_usage_input_gauge{model=~\"$model\"} unless delta(llm_usage_input_gauge{model=~\"$model\"}[$__rate_interval]) == 0",
+                        "format": "time_series",
+                        "legendFormat": "prompt",
                         "range": true
-                      },
-                      "labels": {
-                        "grafana.app/export-label": "prometheus-1"
-                      }
-                    },
-                    "refId": "A",
-                    "hidden": false
-                  }
-                }
-              ],
-              "transformations": [],
-              "queryOptions": {}
-            }
-          },
-          "vizConfig": {
-            "kind": "VizConfig",
-            "group": "logs",
-            "version": "13.0.1+security-01",
-            "spec": {
-              "options": {
-                "dedupStrategy": "none",
-                "detailsMode": "inline",
-                "displayedFields": [
-                  "chat",
-                  "function",
-                  "model",
-                  "Value"
-                ],
-                "enableInfiniteScrolling": false,
-                "enableLogDetails": true,
-                "prettifyLogMessage": true,
-                "showControls": false,
-                "showFieldSelector": false,
-                "showLabels": false,
-                "showLevel": true,
-                "showTime": true,
-                "sortOrder": "Ascending",
-                "timestampResolution": "ms",
-                "unwrappedColumns": true,
-                "wrapLogMessage": false
-              },
-              "fieldConfig": {
-                "defaults": {},
-                "overrides": [
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "scope": "series",
-                      "options": "instance"
-                    },
-                    "properties": []
-                  },
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "scope": "series",
-                      "options": "job"
-                    },
-                    "properties": []
-                  },
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "scope": "series",
-                      "options": "__name__"
-                    },
-                    "properties": []
-                  }
-                ]
-              }
-            }
-          }
-        }
-      },
-      "panel-7": {
-        "kind": "Panel",
-        "spec": {
-          "id": 7,
-          "title": "Общее (derivative)",
-          "description": "",
-          "links": [],
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "query": {
-                      "kind": "DataQuery",
-                      "group": "prometheus",
-                      "version": "v0",
-                      "spec": {
-                        "editorMode": "builder",
-                        "exemplar": false,
-                        "expr": "sum(increase(llm_usage_input[$__rate_interval]))",
-                        "legendFormat": "prompt_total",
-                        "range": true
-                      },
-                      "labels": {
-                        "grafana.app/export-label": "prometheus-1"
                       }
                     },
                     "refId": "A",
@@ -304,14 +69,11 @@
                       "group": "prometheus",
                       "version": "v0",
                       "spec": {
-                        "editorMode": "builder",
-                        "expr": "sum(increase(llm_usage_input_cache_hit[$__rate_interval]))",
+                        "editorMode": "code",
+                        "expr": "llm_usage_input_cache_hit_gauge{model=~\"$model\"} unless delta(llm_usage_input_gauge{model=~\"$model\"}[$__rate_interval]) == 0",
                         "instant": false,
-                        "legendFormat": "prompt_cache_hit",
+                        "legendFormat": "prompt cache hit (cheap)",
                         "range": true
-                      },
-                      "labels": {
-                        "grafana.app/export-label": "prometheus-1"
                       }
                     },
                     "refId": "B",
@@ -326,14 +88,11 @@
                       "group": "prometheus",
                       "version": "v0",
                       "spec": {
-                        "editorMode": "builder",
-                        "expr": "sum(increase(llm_usage_input_cache_miss[$__rate_interval]))",
+                        "editorMode": "code",
+                        "expr": "llm_usage_input_cache_miss_gauge{model=~\"$model\"} unless delta(llm_usage_input_gauge{model=~\"$model\"}[$__rate_interval]) == 0",
                         "instant": false,
-                        "legendFormat": "prompt_cache_miss",
+                        "legendFormat": "prompt cache miss (expensive)",
                         "range": true
-                      },
-                      "labels": {
-                        "grafana.app/export-label": "prometheus-1"
                       }
                     },
                     "refId": "C",
@@ -348,14 +107,11 @@
                       "group": "prometheus",
                       "version": "v0",
                       "spec": {
-                        "editorMode": "builder",
-                        "expr": "sum(increase(llm_usage_output[$__rate_interval]))",
+                        "editorMode": "code",
+                        "expr": "llm_usage_output_gauge{model=~\"$model\"} unless delta(llm_usage_input_gauge{model=~\"$model\"}[$__rate_interval]) == 0",
                         "instant": false,
-                        "legendFormat": "output",
+                        "legendFormat": "output (expensive)",
                         "range": true
-                      },
-                      "labels": {
-                        "grafana.app/export-label": "prometheus-1"
                       }
                     },
                     "refId": "D",
@@ -385,7 +141,1109 @@
                 },
                 "tooltip": {
                   "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 13,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "prompt_cache_miss"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "light-red",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "prompt_cache_hit"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "super-light-green",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "prompt cache hit (cheap)"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "super-light-green",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "prompt cache miss (expensive)"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "orange",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "output (expensive)"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-11": {
+        "kind": "Panel",
+        "spec": {
+          "id": 11,
+          "title": "По названию тула",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "builder",
+                        "exemplar": false,
+                        "expr": "sum by(function) (idelta(tool_call_total[1m]))",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {
+                "maxDataPoints": 500
+              }
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "heatmap",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "calculate": false,
+                "cellGap": 1,
+                "color": {
+                  "exponent": 0.5,
+                  "fill": "dark-orange",
+                  "max": 10,
+                  "mode": "scheme",
+                  "reverse": false,
+                  "scale": "exponential",
+                  "scheme": "Oranges",
+                  "steps": 64
+                },
+                "exemplars": {
+                  "color": "rgba(255,0,255,0.7)"
+                },
+                "filterValues": {
+                  "le": 1e-9
+                },
+                "legend": {
+                  "show": true
+                },
+                "rowsFrame": {
+                  "layout": "auto"
+                },
+                "tooltip": {
                   "mode": "single",
+                  "showColorScale": false,
+                  "yHistogram": false
+                },
+                "yAxis": {
+                  "axisPlacement": "left",
+                  "reverse": false
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "scaleDistribution": {
+                      "type": "linear"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-12": {
+        "kind": "Panel",
+        "spec": {
+          "id": 12,
+          "title": "Топ дрочеров куни по отрпавленным сообщениям",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sort_desc(sum by(chat) (increase(tool_call_total[$__range])))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "",
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "joinByField",
+                  "spec": {
+                    "disabled": true,
+                    "options": {
+                      "byField": "chat",
+                      "mode": "outer"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 8,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": true
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "min": 0,
+                  "max": 100,
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 30,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 50,
+                        "color": "red"
+                      },
+                      {
+                        "value": 80,
+                        "color": "dark-red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "без открытого чата"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-14": {
+        "kind": "Panel",
+        "spec": {
+          "id": 14,
+          "title": "Время ответа (4ч)",
+          "description": "Время, прошедшее с момента отправки последнего сообщения (отправитель неважен) до момента отправки сообщения ботом\n\n",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "avg by(chat) (tool_call_response_time_seconds_gauge{tool=\"send_telegram_message\"} unless delta(tool_call_response_time_seconds_gauge{tool=\"send_telegram_message\"}[$__rate_interval]) == 0)",
+                        "fromExploreMetrics": false,
+                        "legendFormat": "{{chat}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "tool_call_response_time_seconds_gauge",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {
+                "maxDataPoints": 500
+              }
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "heatmap",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "calculate": false,
+                "cellGap": 1,
+                "cellValues": {
+                  "unit": "s"
+                },
+                "color": {
+                  "exponent": 0.5,
+                  "fill": "dark-orange",
+                  "max": 14400,
+                  "min": 1,
+                  "mode": "scheme",
+                  "reverse": true,
+                  "scale": "exponential",
+                  "scheme": "Magma",
+                  "steps": 64
+                },
+                "exemplars": {
+                  "color": "rgba(255,0,255,0.7)"
+                },
+                "filterValues": {
+                  "le": 1e-9
+                },
+                "legend": {
+                  "show": true
+                },
+                "rowsFrame": {
+                  "layout": "auto"
+                },
+                "tooltip": {
+                  "mode": "single",
+                  "showColorScale": false,
+                  "yHistogram": false
+                },
+                "yAxis": {
+                  "axisPlacement": "left",
+                  "reverse": false
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "s",
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "scaleDistribution": {
+                      "type": "linear"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-16": {
+        "kind": "Panel",
+        "spec": {
+          "id": 16,
+          "title": "Возвращения к диалогам",
+          "description": "Чаты, в которых бот отправил сообщения спустя некоторое время.\n\nТакже график отображает, сообщение было отправлено в ответ пользователю, или бот сам решил вернуться и написать.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "avg by(chat) (tool_call_response_time_seconds_gauge{tool=\"send_telegram_message\"} unless delta(tool_call_response_time_seconds_gauge{tool=\"send_telegram_message\"}[$__rate_interval]) == 0)",
+                        "fromExploreMetrics": false,
+                        "legendFormat": "{{chat}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "tool_call_response_time_seconds",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "avg by(scenario) (tool_call_response_time_seconds_gauge{tool=\"send_telegram_message\"} unless delta(tool_call_response_time_seconds_gauge{tool=\"send_telegram_message\"}[$__rate_interval]) == 0)",
+                        "instant": false,
+                        "legendFormat": "{{scenario}}",
+                        "range": true
+                      },
+                      "labels": {
+                        "grafana.app/export-label": "prometheus-1"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {
+                "maxDataPoints": 500
+              }
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": true,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "s",
+                  "decimals": 0,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 28800,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "axisSoftMax": 2592000,
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "points",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 8,
+                    "scaleDistribution": {
+                      "log": 10,
+                      "type": "log"
+                    },
+                    "showPoints": "always",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "fieldMinMax": false
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "kuni proactive"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "#baff00",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.pointSize",
+                        "value": 11
+                      },
+                      {
+                        "id": "custom.drawStyle",
+                        "value": "bars"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "reply to user"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "#5795f21f",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.pointSize",
+                        "value": 14
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-17": {
+        "kind": "Panel",
+        "spec": {
+          "id": 17,
+          "title": "Проактивная проверка чатиков",
+          "description": "Затраченные токены на чаты, в которых последнее сообщение отправлено ботом.\n\nГрафик отображает чаты, которые бот посещает сам (без уведомления).",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "avg by(chat) (llm_usage_input{scenario=\"kuni proactive\"} unless delta(llm_usage_input{scenario=\"kuni proactive\"}[$__interval]) == 0)",
+                        "fromExploreMetrics": false,
+                        "legendFormat": "{{chat}}",
+                        "range": true
+                      }
+                    },
+                    "refId": "tool_call_response_time_seconds",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {
+                "maxDataPoints": 500
+              }
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "heatmap",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "calculate": false,
+                "cellGap": 1,
+                "cellValues": {
+                  "unit": "none"
+                },
+                "color": {
+                  "exponent": 1e-7,
+                  "fill": "dark-orange",
+                  "max": 1000000,
+                  "min": 1,
+                  "mode": "scheme",
+                  "reverse": false,
+                  "scale": "exponential",
+                  "scheme": "Magma",
+                  "steps": 128
+                },
+                "exemplars": {
+                  "color": "rgba(255,0,255,0.7)"
+                },
+                "filterValues": {
+                  "le": 1e-9
+                },
+                "legend": {
+                  "show": true
+                },
+                "rowsFrame": {
+                  "layout": "auto"
+                },
+                "tooltip": {
+                  "mode": "single",
+                  "showColorScale": false,
+                  "yHistogram": false
+                },
+                "yAxis": {
+                  "axisPlacement": "left",
+                  "reverse": false
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "s",
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "scaleDistribution": {
+                      "type": "linear"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-19": {
+        "kind": "Panel",
+        "spec": {
+          "id": 19,
+          "title": "Инициированные диалоги",
+          "description": "Чаты, в которых бот отправил сообщения сам по своей инициативе.\n",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "histogram_quantile(0.5, sum by(chat, le) (increase(tool_call_response_time_seconds_bucket{tool=\"send_telegram_message\",scenario=\"kuni proactive\"}[$__rate_interval])))",
+                        "fromExploreMetrics": false,
+                        "legendFormat": "{{chat}} p50",
+                        "range": true
+                      }
+                    },
+                    "refId": "tool_call_response_time_seconds",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {
+                "maxDataPoints": 500
+              }
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": true,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "s",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "points",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 8,
+                    "scaleDistribution": {
+                      "log": 2,
+                      "type": "log"
+                    },
+                    "showPoints": "always",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "Топ дрочеров куни по токенам",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by(chat) (sort_desc(increase(llm_usage_input[$__range])))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "joinByField",
+                  "spec": {
+                    "disabled": true,
+                    "options": {
+                      "byField": "chat",
+                      "mode": "outer"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 8,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": true
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "min": 0,
+                  "max": 5000000,
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 30,
+                        "color": "#EAB839"
+                      },
+                      {
+                        "value": 50,
+                        "color": "red"
+                      },
+                      {
+                        "value": 80,
+                        "color": "dark-red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-7": {
+        "kind": "Panel",
+        "spec": {
+          "id": 7,
+          "title": "Общее (ты за это бабки платишь)",
+          "description": "Эти значения соответствуют тому, что появится в биллинге у AI-провайдера.\n\nВажно учитывать: цифры будут значительно выше абсолютного размера контекста — потому что весь накопленный контекст передаётся в LLM при каждом запросе (такова архитектура LLM).\n\nЕдинственное, что сдерживает расходы - input cache hit.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "builder",
+                        "exemplar": false,
+                        "expr": "sum(increase(llm_usage_input[$__rate_interval]))",
+                        "legendFormat": "prompt",
+                        "range": true
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "builder",
+                        "expr": "sum(increase(llm_usage_input_cache_hit[$__rate_interval]))",
+                        "instant": false,
+                        "legendFormat": "prompt cache hit (cheap)",
+                        "range": true
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "builder",
+                        "expr": "sum(increase(llm_usage_input_cache_miss[$__rate_interval]))",
+                        "instant": false,
+                        "legendFormat": "prompt cache miss (expensive)",
+                        "range": true
+                      }
+                    },
+                    "refId": "C",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus",
+                      "version": "v0",
+                      "spec": {
+                        "editorMode": "builder",
+                        "expr": "sum(increase(llm_usage_output[$__rate_interval]))",
+                        "instant": false,
+                        "legendFormat": "output (expensive)",
+                        "range": true
+                      }
+                    },
+                    "refId": "D",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {
+                "maxDataPoints": 500
+              }
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.1+security-01",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": true,
+                  "mode": "multi",
                   "sort": "none"
                 }
               },
@@ -487,6 +1345,51 @@
                         }
                       }
                     ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "prompt cache hit (cheap)"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "super-light-green",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "prompt cache miss (expensive)"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "orange",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "output (expensive)"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
@@ -517,9 +1420,6 @@
                         "expr": "sum by(function) (increase(llm_usage_input[$__rate_interval]))",
                         "legendFormat": "{{label_name}}",
                         "range": true
-                      },
-                      "labels": {
-                        "grafana.app/export-label": "prometheus-1"
                       }
                     },
                     "refId": "A",
@@ -528,12 +1428,14 @@
                 }
               ],
               "transformations": [],
-              "queryOptions": {}
+              "queryOptions": {
+                "maxDataPoints": 500
+              }
             }
           },
           "vizConfig": {
             "kind": "VizConfig",
-            "group": "timeseries",
+            "group": "heatmap",
             "version": "13.0.1+security-01",
             "spec": {
               "options": {
@@ -541,68 +1443,51 @@
                   "clustering": -1,
                   "multiLane": false
                 },
+                "calculate": false,
+                "cellGap": 1,
+                "color": {
+                  "exponent": 0.5,
+                  "fill": "dark-orange",
+                  "max": 1000000,
+                  "min": 0,
+                  "mode": "scheme",
+                  "reverse": false,
+                  "scale": "exponential",
+                  "scheme": "Oranges",
+                  "steps": 64
+                },
+                "exemplars": {
+                  "color": "rgba(255,0,255,0.7)"
+                },
+                "filterValues": {
+                  "le": 1e-9
+                },
                 "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
+                  "show": true
+                },
+                "rowsFrame": {
+                  "layout": "auto"
                 },
                 "tooltip": {
-                  "hideZeros": false,
                   "mode": "single",
-                  "sort": "none"
+                  "showColorScale": false,
+                  "yHistogram": false
+                },
+                "yAxis": {
+                  "axisPlacement": "left",
+                  "reverse": false
                 }
               },
               "fieldConfig": {
                 "defaults": {
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
                   "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 30,
-                    "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
                       "tooltip": false,
                       "viz": false
                     },
-                    "insertNulls": false,
-                    "lineInterpolation": "smooth",
-                    "lineWidth": 1,
-                    "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
                     }
                   }
                 },
@@ -612,30 +1497,14 @@
                       "id": "byName",
                       "options": "ask_diary"
                     },
-                    "properties": [
-                      {
-                        "id": "color",
-                        "value": {
-                          "fixedColor": "dark-blue",
-                          "mode": "fixed"
-                        }
-                      }
-                    ]
+                    "properties": []
                   },
                   {
                     "matcher": {
                       "id": "byName",
                       "options": "notification processing loop"
                     },
-                    "properties": [
-                      {
-                        "id": "color",
-                        "value": {
-                          "fixedColor": "yellow",
-                          "mode": "fixed"
-                        }
-                      }
-                    ]
+                    "properties": []
                   },
                   {
                     "matcher": {
@@ -649,15 +1518,7 @@
                       "id": "byName",
                       "options": "diaryDumpMessages"
                     },
-                    "properties": [
-                      {
-                        "id": "color",
-                        "value": {
-                          "fixedColor": "light-blue",
-                          "mode": "fixed"
-                        }
-                      }
-                    ]
+                    "properties": []
                   }
                 ]
               }
@@ -686,11 +1547,8 @@
                       "spec": {
                         "editorMode": "builder",
                         "expr": "sum by(chat) (increase(llm_usage_input[$__rate_interval]))",
-                        "legendFormat": "{{label_name}}",
+                        "legendFormat": "{{chat}}",
                         "range": true
-                      },
-                      "labels": {
-                        "grafana.app/export-label": "prometheus-1"
                       }
                     },
                     "refId": "A",
@@ -699,12 +1557,14 @@
                 }
               ],
               "transformations": [],
-              "queryOptions": {}
+              "queryOptions": {
+                "maxDataPoints": 500
+              }
             }
           },
           "vizConfig": {
             "kind": "VizConfig",
-            "group": "timeseries",
+            "group": "heatmap",
             "version": "13.0.1+security-01",
             "spec": {
               "options": {
@@ -712,68 +1572,54 @@
                   "clustering": -1,
                   "multiLane": false
                 },
+                "calculate": false,
+                "cellGap": 1,
+                "color": {
+                  "exponent": 0.5,
+                  "fill": "dark-orange",
+                  "max": 500000,
+                  "mode": "scheme",
+                  "reverse": false,
+                  "scale": "exponential",
+                  "scheme": "Oranges",
+                  "steps": 64
+                },
+                "exemplars": {
+                  "color": "rgba(255,0,255,0.7)"
+                },
+                "filterValues": {
+                  "le": 1e-9
+                },
                 "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
+                  "calcs": [
+                    "sum"
+                  ],
+                  "show": true
+                },
+                "rowsFrame": {
+                  "layout": "auto"
                 },
                 "tooltip": {
-                  "hideZeros": false,
                   "mode": "single",
-                  "sort": "none"
+                  "showColorScale": true,
+                  "yHistogram": false
+                },
+                "yAxis": {
+                  "axisPlacement": "left",
+                  "axisWidth": 150,
+                  "reverse": true
                 }
               },
               "fieldConfig": {
                 "defaults": {
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": 0,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
                   "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 13,
-                    "gradientMode": "none",
                     "hideFrom": {
                       "legend": false,
                       "tooltip": false,
                       "viz": false
                     },
-                    "insertNulls": false,
-                    "lineInterpolation": "smooth",
-                    "lineWidth": 1,
-                    "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
                     }
                   }
                 },
@@ -791,9 +1637,9 @@
           {
             "kind": "RowsLayoutRow",
             "spec": {
-              "title": "New row 1",
+              "title": "LLM token usage",
               "collapse": false,
-              "hideHeader": true,
+              "hideHeader": false,
               "fillScreen": false,
               "layout": {
                 "kind": "AutoGridLayout",
@@ -819,6 +1665,19 @@
                           "name": "panel-8"
                         }
                       }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-10"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "model"
+                        }
+                      }
                     }
                   ]
                 }
@@ -840,7 +1699,7 @@
                         "x": 0,
                         "y": 0,
                         "width": 24,
-                        "height": 11,
+                        "height": 21,
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-9"
@@ -851,9 +1710,9 @@
                       "kind": "GridLayoutItem",
                       "spec": {
                         "x": 0,
-                        "y": 11,
-                        "width": 8,
-                        "height": 10,
+                        "y": 21,
+                        "width": 9,
+                        "height": 17,
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-3"
@@ -863,13 +1722,93 @@
                     {
                       "kind": "GridLayoutItem",
                       "spec": {
-                        "x": 0,
+                        "x": 9,
                         "y": 21,
-                        "width": 24,
-                        "height": 11,
+                        "width": 9,
+                        "height": 17,
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-5"
+                          "name": "panel-12"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Действия",
+              "collapse": false,
+              "fillScreen": true,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 24,
+                        "height": 9,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-11"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 9,
+                        "width": 24,
+                        "height": 9,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-14"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 18,
+                        "width": 24,
+                        "height": 16,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-16"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 34,
+                        "width": 24,
+                        "height": 9,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-19"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "x": 0,
+                        "y": 43,
+                        "width": 24,
+                        "height": 9,
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-17"
                         }
                       }
                     }
@@ -922,6 +1861,39 @@
         },
         "labels": {
           "grafana.app/export-label": "prometheus-1"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "name": "model",
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "label": "",
+          "hide": "hideVariable",
+          "refresh": "onDashboardLoad",
+          "skipUrlSync": false,
+          "description": "Используемая модель LLM",
+          "query": {
+            "kind": "DataQuery",
+            "group": "prometheus",
+            "version": "v0",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(llm_usage_input_gauge,model)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            }
+          },
+          "regex": "",
+          "regexApplyTo": "value",
+          "sort": "disabled",
+          "definition": "label_values(llm_usage_input_gauge,model)",
+          "options": [],
+          "multi": true,
+          "includeAll": true,
+          "allowCustomValue": false
         }
       }
     ],

--- a/src/AppBase.cpp
+++ b/src/AppBase.cpp
@@ -61,7 +61,7 @@ AFuture<std::valarray<double>> contextEmbedding(IOpenAIChat& openAI, ranges::ran
 AppBase::AppBase(Init init): mInit(std::move(init)), mDiary({
     .diaryDir = mInit.workingDir / "diary",
     .openAI = mInit.openAI,
-}), mWakeupTimer(_new<ATimer>(200min)) {
+}), mWakeupTimer(_new<ATimer>(11min)) {
     // mTools.addTool({
     //     .name = "send_telegram_message",
     //     .description = "Sends a message to a Telegram user.",
@@ -225,6 +225,15 @@ AppBase::AppBase(Init init): mInit(std::move(init)), mDiary({
                     self.updateTools(notification.actions);
                     auto escape = [&](OpenAITools::Ctx ctx) -> AFuture<AString> {
                         pauseFlag = true;
+                        if (self.mActingProactively) {
+                            // at the end of "actProactively", let's try to encourage LLM to write someone, still.
+                            // if LLM's haven't written to anyone at this point, this notification will guide the LLM
+                            // that dismissive action is not acceptable and LLM will try to revisit some older dialog
+                            // despite no cue.
+                            // if LLM actually have written to someone at this point, LLM will initiate a dialog with
+                            // one more person.
+                            self.passNotificationToAI("You should write someone else and be more proactive.", {}, true);
+                        }
                         co_return "Success";
                     };
                     notification.actions.insert({
@@ -451,11 +460,17 @@ It's time to reflect on your thoughts!
 Act proactively!
 )";
     const auto& notification = passNotificationToAI(std::move(prompt));
-    notification.onStartedProcessing.onSuccess([&] {
+    struct State {
+        AOptional<MetricsBreadcumbs::Point> metric;
+    };
+    auto state = _new<State>();
+    notification.onStartedProcessing.onSuccess([this, state] {
         mActingProactively = true;
+        state->metric.emplace(metricBreadcumbs(), "function", "actProactively");
     });
-    notification.onProcessed.onSuccess([&] {
+    notification.onProcessed.onSuccess([this, state] {
         mActingProactively = false;
+        state->metric = std::nullopt;
     });
 }
 
@@ -463,9 +478,7 @@ AFuture<AString> AppBase::onCleanContext() {
     if ((mInit.workingDir / WORKING_MEMORY_PATH).isRegularFileExists()) {
         AByteBuffer workingMemory;
         workingMemory << AFileInputStream(mInit.workingDir / WORKING_MEMORY_PATH);
-        co_return "<things_to_remember>\n{}\n</things_to_remember>\n"
-            "You should take action only if you have found a task to do from above.\n"
-            "Otherwise, just call #wait.\n"_format(AStringView(workingMemory.data(), workingMemory.size()));
+        co_return "<things_to_remember>\n{}\n</things_to_remember>\n"_format(AStringView(workingMemory.data(), workingMemory.size()));
     }
     co_return "";
 }
@@ -475,6 +488,23 @@ void AppBase::updateTools(OpenAITools& actions) {
     ALOG_TRACE(LOG_TAG) << "updateTools";
     actions.insert(tools::askDiary(mTemporaryContext, mDiary));
     actions.insert(tools::askGoogle(openAI()));
+    actions.onAfterToolCall = [this](const AString& toolName) {
+        if (toolName == "wait") {
+            return;
+        }
+        if (toolName == "pause") {
+            return;
+        }
+        auto labels = metricBreadcumbs()->value();
+        emit toolCallFired(AppBase::ToolCallEvent{
+            .toolName = toolName,
+            .breadcrumbLabels = std::move(labels),
+            .lastOpenedChatLastMessageTime = mLastOpenedChatLastMessageTime.map([](std::chrono::system_clock::time_point t) {
+                return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - t);
+            }),
+        });
+    };
+
 }
 
 void AppBase::removeNotifications(const AString& substring) {

--- a/src/AppBase.h
+++ b/src/AppBase.h
@@ -50,6 +50,13 @@ public:
      */
     [[nodiscard]] bool isActingProactively() const { return mActingProactively; }
 
+    struct ToolCallEvent {
+        AString toolName;
+        AMap<AString, AString> breadcrumbLabels;
+        AOptional<std::chrono::seconds> lastOpenedChatLastMessageTime;
+    };
+    emits<ToolCallEvent> toolCallFired;
+
     [[nodiscard]]
     const _<MetricsBreadcumbs>& metricBreadcumbs() const {
         return mMetricBreadcumbs;
@@ -58,8 +65,10 @@ public:
 
 protected:
     AAsyncHolder mAsync;
-
     aui::float_within_0_1 mRelevanceThreshold = 0.5f;
+
+    // Set by llmuiOpenTelegramChat; read by updateTools to populate ToolCallEvent.
+    AOptional<std::chrono::system_clock::time_point> mLastOpenedChatLastMessageTime;
 
     virtual AFuture<AString> onCleanContext();
 

--- a/src/MetricsBreadcumbs.cpp
+++ b/src/MetricsBreadcumbs.cpp
@@ -11,6 +11,7 @@ MetricsBreadcumbs::Point::Point(_<MetricsBreadcumbs> breadcumbs, AString key, AS
     mBreadcumbs(std::move(breadcumbs)),
     mKey(std::move(key)),
     mPrevValue(std::exchange(mBreadcumbs->mValue[mKey], value)) {
+    // ALogger::trace(LOG_TAG) << "MetricsBreadcumbs::Point: key=" << mKey << "; value=" << value;
 
 }
 
@@ -21,5 +22,6 @@ MetricsBreadcumbs::Point::~Point() {
     if (mBreadcumbs == nullptr) {
         return;
     }
+    // ALogger::trace(LOG_TAG) << "MetricsBreadcumbs::~Point: key=" << mKey << "; value=" << mPrevValue;
     mBreadcumbs->mValue[mKey] = std::move(mPrevValue);
 }

--- a/src/OpenAITools.cpp
+++ b/src/OpenAITools.cpp
@@ -54,11 +54,15 @@ AFuture<AVector<IOpenAIChat::Message>> OpenAITools::handleToolCalls(const AVecto
                         if (metricsBreadCumbs) {
                             point.emplace(metricsBreadCumbs, "function", toolCall.function.name);
                         }
-                        co_return co_await c->second.handler({
+                        auto handlerResult = co_await c->second.handler({
                             .tools = *this,
                             .args = AJson::fromString(toolCall.function.arguments),
                             .allToolCalls = toolCalls,
                         });
+                        if (onAfterToolCall) {
+                            onAfterToolCall(toolCall.function.name);
+                        }
+                        co_return std::move(handlerResult);
                     }
                     co_return "tool \"" + toolCall.function.name + "\" is not currently available. Please use another tool instead.";
                 } catch (const AException& e) {

--- a/src/OpenAITools.h
+++ b/src/OpenAITools.h
@@ -33,6 +33,12 @@ struct OpenAITools {
 
     OpenAITools(std::initializer_list<Tool> tools);
 
+    /**
+     * @brief Optional hook fired after each tool call handler completes successfully.
+     * Not called if the handler throws. Set by AppBase::updateTools to emit AppBase::toolCallFired.
+     */
+    std::function<void(const AString& toolName)> onAfterToolCall;
+
     AFuture<AVector<IOpenAIChat::Message>> handleToolCalls(const AVector<IOpenAIChat::Message::ToolCall>& toolCalls, const _<MetricsBreadcumbs>& metricsBreadCumbs = nullptr);
 
     AJson asJson() const;

--- a/src/Prometheus.cpp
+++ b/src/Prometheus.cpp
@@ -4,12 +4,17 @@
 
 #include <prometheus/counter.h>
 #include <prometheus/exposer.h>
+#include <prometheus/histogram.h>
 #include <prometheus/registry.h>
 #include <prometheus/CivetServer.h>
 
 #include "Prometheus.h"
+#include "AppBase.h"
 
 #include <range/v3/all.hpp>
+
+using namespace std::chrono;
+using namespace std::chrono_literals;
 
 namespace {
 
@@ -44,9 +49,9 @@ struct PrometheusImpl: AObject, prometheus::IExporter {
         exposer.RegisterCollectable(registry);
     }
 
-    prometheus::Labels breadcumbsLabels() const {
+    static prometheus::Labels fromMap(const AMap<AString, AString>& map) {
         prometheus::Labels out;
-        for (const auto&[k,v] : metricBreadcumbs->value()) {
+        for (const auto&[k,v] : map) {
             if (v.empty()) {
                 continue;
             }
@@ -55,35 +60,112 @@ struct PrometheusImpl: AObject, prometheus::IExporter {
         return out;
     }
 
+    prometheus::Labels breadcumbsLabels() const {
+        return fromMap(metricBreadcumbs->value());
+    }
+
     void registerOpenAI(OpenAIChatMeasurable& chat) override {
-        auto& input = prometheus::BuildCounter()
-            .Name("llm_usage_input")
-            .Help("OpenAI endpoint token usage (input tokens)")
+        {
+            auto& input = prometheus::BuildCounter()
+                .Name("llm_usage_input")
+                .Help("OpenAI endpoint token usage (input tokens)")
+                .Register(*registry)
+            ;
+            auto& input_cache_hit = prometheus::BuildCounter()
+                .Name("llm_usage_input_cache_hit")
+                .Help("OpenAI endpoint token usage (input tokens that were cached; cheap)")
+                .Register(*registry)
+            ;
+            auto& input_cache_miss = prometheus::BuildCounter()
+                .Name("llm_usage_input_cache_miss")
+                .Help("OpenAI endpoint token usage (input tokens that weren't; expensive)")
+                .Register(*registry)
+            ;
+            auto& output = prometheus::BuildCounter()
+                .Name("llm_usage_output")
+                .Help("OpenAI endpoint token usage (output tokens; expensive)")
+                .Register(*registry)
+            ;
+            connect(chat.responseMetrics, [&](OpenAIChatMeasurable::Metrics usage) {
+                auto base = breadcumbsLabels() + prometheus::Labels {
+                    {"model", usage.model},
+                };
+                input.Add(base).Increment(usage.usage.prompt_tokens);
+                input_cache_hit.Add(base).Increment(usage.usage.prompt_cache_hit_tokens);
+                input_cache_miss.Add(base).Increment(usage.usage.prompt_cache_miss_tokens);
+                output.Add(base).Increment(usage.usage.completion_tokens);
+            });
+        }
+        {
+
+            auto& input = prometheus::BuildGauge()
+                .Name("llm_usage_input_gauge")
+                .Help("OpenAI endpoint last query input tokens")
+                .Register(*registry)
+            ;
+            auto& input_cache_hit = prometheus::BuildGauge()
+                .Name("llm_usage_input_cache_hit_gauge")
+                .Help("OpenAI endpoint last query input tokens that were cached; cheap")
+                .Register(*registry)
+            ;
+            auto& input_cache_miss = prometheus::BuildGauge()
+                .Name("llm_usage_input_cache_miss_gauge")
+                .Help("OpenAI endpoint last query input tokens that weren't cached; expensive")
+                .Register(*registry)
+            ;
+            auto& output = prometheus::BuildGauge()
+                .Name("llm_usage_output_gauge")
+                .Help("OpenAI endpoint last query output tokens; expensive")
+                .Register(*registry)
+            ;
+            connect(chat.responseMetrics, [&](OpenAIChatMeasurable::Metrics usage) {
+                auto base = prometheus::Labels {
+                    {"model", usage.model},
+                };
+                input.Add(base).Set(usage.usage.prompt_tokens);
+                input_cache_hit.Add(base).Set(usage.usage.prompt_cache_hit_tokens);
+                input_cache_miss.Add(base).Set(usage.usage.prompt_cache_miss_tokens);
+                output.Add(base).Set(usage.usage.completion_tokens);
+            });
+        }
+    }
+
+    void registerAppBase(AppBase& app) override {
+        auto& toolCallCounter = prometheus::BuildCounter()
+            .Name("tool_call_total")
+            .Help("Number of tool calls dispatched by the LLM, labelled by tool name, chat, and scenario")
             .Register(*registry)
         ;
-        auto& input_cache_hit = prometheus::BuildCounter()
-            .Name("llm_usage_input_cache_hit")
-            .Help("OpenAI endpoint token usage (input tokens that were cached; cheap)")
+        // Buckets cover: 1min, 5min, 15min, 30min, 1h, 2h, 4h, 8h, 1d, 3d, 7d, 14d, 30d
+        auto& responseTimeHistogram = prometheus::BuildHistogram()
+            .Name("tool_call_response_time_seconds")
+            .Help("Time between the last message in the chat and the bot's tool call dispatch, as a histogram")
             .Register(*registry)
         ;
-        auto& input_cache_miss = prometheus::BuildCounter()
-            .Name("llm_usage_input_cache_miss")
-            .Help("OpenAI endpoint token usage (input tokens that weren't; expensive)")
+        auto& responseTimeGauge = prometheus::BuildGauge()
+            .Name("tool_call_response_time_seconds_gauge")
+            .Help("Time between the last message in the chat and the bot's tool call dispatch, as a gauge")
             .Register(*registry)
         ;
-        auto& output = prometheus::BuildCounter()
-            .Name("llm_usage_output")
-            .Help("OpenAI endpoint token usage (output tokens)")
-            .Register(*registry)
-        ;
-        connect(chat.responseMetrics, [&](OpenAIChatMeasurable::Metrics usage) {
-            auto base = breadcumbsLabels() + prometheus::Labels {
-                {"model", usage.model},
-            };
-            input.Add(base).Increment(usage.usage.prompt_tokens);
-            input_cache_hit.Add(base).Increment(usage.usage.prompt_cache_hit_tokens);
-            input_cache_miss.Add(base).Increment(usage.usage.prompt_cache_miss_tokens);
-            output.Add(base).Increment(usage.usage.completion_tokens);
+        static const prometheus::Histogram::BucketBoundaries kResponseTimeBuckets = {
+            5,
+            10,
+            15,
+            20,
+            30,
+            40,
+            50,
+            60, 300, 900, 1800, 3600, 7200, 14400, 28800, 86400, 259200, 604800, 1209600, 2592000
+        };
+        connect(app.toolCallFired, [&](AppBase::ToolCallEvent ev) {
+            // ALogger::info("Prometheus") << "toolCallFired: " << ev.toolName << ", chat=" << ev.breadcrumbLabels["chat"];
+            auto labels = fromMap(ev.breadcrumbLabels);
+            labels["tool"] = ev.toolName;
+            toolCallCounter.Add(labels).Increment();
+            if (ev.lastOpenedChatLastMessageTime) {
+                responseTimeHistogram.Add(labels, kResponseTimeBuckets).Observe(static_cast<double>(ev.lastOpenedChatLastMessageTime->count()));
+                responseTimeGauge.Add(labels).Set(static_cast<double>(ev.lastOpenedChatLastMessageTime->count()));
+            }
         });
     }
 };

--- a/src/Prometheus.h
+++ b/src/Prometheus.h
@@ -9,6 +9,7 @@ public:
     virtual ~IExporter() = default;
 
     virtual void registerOpenAI(OpenAIChatMeasurable& chat) = 0;
+    virtual void registerAppBase(AppBase& app) = 0;
 };
 
 _<IExporter> setup(_<MetricsBreadcumbs> metricBreadcumbs);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,8 @@
 
 #include "util/json_utils.h"
 
+#include <range/v3/view/take.hpp>
+
 using namespace std::chrono_literals;
 
 std::default_random_engine gRandomEngine(std::time(nullptr));
@@ -142,6 +144,7 @@ protected:
 
 private:
     _<ITelegramClient> mTelegram;
+    std::list<MetricsBreadcumbs::Point> mLastOpenedChatLastMetrics;
 
     AFuture<AVector<td::td_api::object_ptr<td::td_api::chat>>> chatIdsToChats(std::span<td::td_api::int53> ids) {
         auto chats =
@@ -287,22 +290,22 @@ public:
         removeNotifications("<notification chat_id=\"{}\">\n"_format(chatId));
 
         _<td::td_api::chat> chat;
+        mLastOpenedChatLastMetrics = std::list<MetricsBreadcumbs::Point>{};
         {
             auto chatTgPtr = co_await mTelegram->sendQueryWithResult(ITelegramClient::toPtr(td::td_api::getChat(chatId)));
-            auto metric = _new<MetricsBreadcumbs::Point>(metricBreadcumbs(), "chat", chatTgPtr->title_);
             chat = aui::ptr::manage_shared(
                 chatTgPtr.release(),
-                [this, self = shared_from_this(), metric](td::td_api::chat* chat) {
+                [this, self = shared_from_this()](td::td_api::chat* chat) {
                     try {
                         setOnline(false);
                         mTelegram->sendQuery(ITelegramClient::toPtr(td::td_api::sendChatAction(chat->id_, {}, {}, nullptr)));
                         mTelegram->sendQuery(ITelegramClient::toPtr(td::td_api::closeChat(chat->id_)));
-                        AUI_NO_OPTIMIZE_OUT(metric); // just to ensure the lifetime of metric
                     } catch (...) {
                     }
                     delete chat;
                 });
         }
+        mLastOpenedChatLastMetrics.emplace_back(metricBreadcumbs(), "chat", chat->title_);
 
         AString result;
 
@@ -343,6 +346,33 @@ public:
             }
         }
         ALOG_DEBUG(LOG_TAG) << "Loaded " << messages.size() << " message(s): " << chat->title_;
+
+        // Compute response-time metadata for Prometheus. messages[0] is the most recent.
+        mLastOpenedChatLastMessageTime = [&]() -> AOptional<std::chrono::system_clock::time_point> {
+            if (messages.empty()) {
+                return std::nullopt;
+            }
+            return std::chrono::system_clock::from_time_t(messages.front()->date_);
+        }();
+        mLastOpenedChatLastMetrics.emplace_back(metricBreadcumbs(), "scenario", [&] {
+            if (messages.empty()) {
+                // this means Kuni sent a message to a new person.
+                return "new conversation";
+            }
+
+            td::td_api::int53 senderId = 0;
+            td::td_api::downcast_call(
+                *messages.front()->sender_id_,
+                aui::lambda_overloaded {
+                  [&](td::td_api::messageSenderUser& user) { senderId = user.user_id_; },
+                  [](auto&) {},
+                });
+            if (senderId == mTelegram->myId()) {
+                // last message is from Kuni.
+                return "kuni proactive";
+            }
+            return "reply to user";
+        }());
         if (messages.empty()) {
             // Kuni sometimes opens random chats?
             // throw AException("Failed to open chat");
@@ -540,7 +570,6 @@ AUI_ENTRY {
     async << [](_<ITelegramClient> telegram) -> AFuture<> {
         ALogger::info(LOG_TAG) << "Waiting for Telegram network...";
         co_await telegram->waitForConnection();
-        ALogger::info(LOG_TAG) << "Connected to Telegram";
         switch (config::LOCKDOWN_MODE) {
             case config::LockdownMode::NONE:
                 break;
@@ -561,6 +590,7 @@ AUI_ENTRY {
         app = _new<App>(telegram, openAI);
         prometheus = prometheus::setup(app->metricBreadcumbs());
         prometheus->registerOpenAI(*openAI);
+        prometheus->registerAppBase(*app);
         _new<AThread>([] {
             ALogger::info(LOG_TAG) << "Bot is up and running. Press enter to shutdown gracefully.";
             std::cin.get();

--- a/tests/PrometheusUnitTest.cpp
+++ b/tests/PrometheusUnitTest.cpp
@@ -1,0 +1,399 @@
+//
+// Unit tests verifying that AppBase pushes ToolCallEvents to IExporter subscribers.
+//
+// Strategy:
+//   - Use a minimal AppBase subclass (PrometheusTestHarness) that:
+//       * wires onAfterToolCall → emit toolCallFired   (mirrors what App::updateTools does in main.cpp)
+//       * exposes a "my_tool" handler that completes successfully
+//       * provides the mandatory "wait" tool to let the main loop stop
+//   - Use a stub IExporter subclass (SpyExporter) that records every ToolCallEvent
+//     received via registerAppBase, without starting a Civet/HTTP server.
+//   - Trigger tool calls via passNotificationToAI and verify the recorded events.
+//
+
+#include <range/v3/all.hpp>
+#include "AppBase.h"
+#include "IOpenAIChat.h"
+#include "OpenAITools.h"
+#include "Prometheus.h"
+#include "MetricsBreadcumbs.h"
+
+#include <gmock/gmock.h>
+#include <AUI/Thread/AAsyncHolder.h>
+#include <AUI/Thread/AEventLoop.h>
+#include <AUI/IO/APath.h>
+
+using namespace std::chrono_literals;
+
+// ============================================================================
+// Mock IOpenAIChat
+// ============================================================================
+class PrometheusOpenAIMock : public IOpenAIChat {
+public:
+    MOCK_METHOD(AFuture<Response>, chat, (Params params, AVector<Message> messages), (override));
+    _<StreamingResponse> chatStreaming(Params params, AVector<Message> messages) override { return nullptr; }
+    MOCK_METHOD(AFuture<std::valarray<double>>, embedding, (Params params, AString input), (override));
+};
+
+// ============================================================================
+// Helper: build a canned LLM response that dispatches the named tool
+// ============================================================================
+static AFuture<IOpenAIChat::Response> makeToolCallResponse(AString toolName, AString args = "{}") {
+    IOpenAIChat::Message msg;
+    msg.role = IOpenAIChat::Message::Role::ASSISTANT;
+    msg.content = "";
+    msg.tool_calls = {
+        IOpenAIChat::Message::ToolCall{
+            .id = "call_1",
+            .index = 0,
+            .type = "function",
+            .function = {
+                .name = std::move(toolName),
+                .arguments = std::move(args),
+            },
+        },
+    };
+
+    IOpenAIChat::Response resp;
+    resp.choices = {
+        IOpenAIChat::Response::Choice{
+            .index = 0,
+            .message = std::move(msg),
+            .finish_reason = "tool_calls",
+        },
+    };
+    resp.usage = { .prompt_tokens = 5, .completion_tokens = 3, .total_tokens = 8 };
+    co_return resp;
+}
+
+// Helper: LLM stops with "wait" (ends the processing loop)
+static AFuture<IOpenAIChat::Response> makeWaitResponse() {
+    return makeToolCallResponse("wait");
+}
+
+// Helper: LLM first calls my_tool, then wait
+static AFuture<IOpenAIChat::Response> makeMyToolResponse() {
+    return makeToolCallResponse("my_tool");
+}
+
+// ============================================================================
+// PrometheusTestHarness — AppBase subclass that:
+//   1. Wires onAfterToolCall → emit toolCallFired  (same pattern as App in main.cpp)
+//   2. Provides "my_tool" (a simple no-op) and "wait" for loop termination
+// ============================================================================
+class PrometheusTestHarness : public AppBase {
+public:
+    AString lastMyToolCallResult;
+
+    explicit PrometheusTestHarness(_<IOpenAIChat> openAI)
+        : AppBase(Init{
+              .workingDir = "test_data_prometheus_unit",
+              .openAI = std::move(openAI),
+          })
+    {
+        APath("test_data_prometheus_unit").removeFileRecursive();
+        mLastOpenedChatLastMessageTime = std::chrono::system_clock::now() - 42s;
+    }
+
+    ~PrometheusTestHarness() override {
+        APath("test_data_prometheus_unit").removeFileRecursive();
+    }
+
+protected:
+    void updateTools(OpenAITools& actions) override {
+        AppBase::updateTools(actions);
+
+        actions.insert({
+            .name = "my_tool",
+            .description = "A test tool",
+            .handler = [this](OpenAITools::Ctx) -> AFuture<AString> {
+                lastMyToolCallResult = "called";
+                co_return "my_tool executed";
+            },
+        });
+        actions.insert({
+            .name = "wait",
+            .description = "Wait until further notifications",
+            .handler = [](OpenAITools::Ctx) -> AFuture<AString> { co_return "Waiting"; },
+        });
+    }
+};
+
+// ============================================================================
+// SpyExporter — an IExporter that captures ToolCallEvents without starting HTTP
+// ============================================================================
+class SpyExporter : public AObject, public prometheus::IExporter {
+public:
+    AVector<AppBase::ToolCallEvent> capturedEvents;
+
+    void registerOpenAI(OpenAIChatMeasurable&) override { /* not tested here */ }
+
+    void registerAppBase(AppBase& app) override {
+        connect(app.toolCallFired, [this](AppBase::ToolCallEvent ev) {
+            capturedEvents << std::move(ev);
+        });
+    }
+};
+
+// ============================================================================
+// Fixture
+// ============================================================================
+class PrometheusUnitTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        APath("test_data_prometheus_unit").removeFileRecursive();
+    }
+    void TearDown() override {
+        APath("test_data_prometheus_unit").removeFileRecursive();
+    }
+};
+
+// ============================================================================
+// toolCallFired is emitted after a tool handler completes
+// ============================================================================
+TEST_F(PrometheusUnitTest, ToolCallFiredOnSuccessfulToolCall) {
+    AEventLoop loop;
+    IEventLoop::Handle h(&loop);
+    AAsyncHolder async;
+
+    auto openAI = _cast<IOpenAIChat>(_new<PrometheusOpenAIMock>());
+    // LLM calls my_tool, then wait
+    EXPECT_CALL(*static_cast<PrometheusOpenAIMock*>(openAI.get()), chat(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(makeMyToolResponse()))
+        .WillOnce(::testing::Return(makeWaitResponse()));
+
+    auto app = _new<PrometheusTestHarness>(openAI);
+    SpyExporter spy;
+    spy.registerAppBase(*app);
+
+    async << app->passNotificationToAI("Hello").onProcessed;
+    while (async.size() > 0) {
+        loop.iteration();
+    }
+
+    // my_tool handler ran
+    EXPECT_EQ(app->lastMyToolCallResult, "called");
+
+    // toolCallFired was emitted once for my_tool (the "wait" call also fires, so at least 1 for my_tool)
+    ASSERT_EQ(spy.capturedEvents.size(), 1);
+    auto& event = spy.capturedEvents.first();
+    EXPECT_EQ(event.toolName, "my_tool");
+}
+
+// ============================================================================
+// toolCallFired carries the correct tool name for each distinct tool
+// ============================================================================
+TEST_F(PrometheusUnitTest, ToolCallFiredCarriesCorrectToolName) {
+    AEventLoop loop;
+    IEventLoop::Handle h(&loop);
+    AAsyncHolder async;
+
+    auto openAI = _cast<IOpenAIChat>(_new<PrometheusOpenAIMock>());
+    EXPECT_CALL(*static_cast<PrometheusOpenAIMock*>(openAI.get()), chat(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(makeMyToolResponse()))
+        .WillOnce(::testing::Return(makeWaitResponse()));
+
+    auto app = _new<PrometheusTestHarness>(openAI);
+    SpyExporter spy;
+    spy.registerAppBase(*app);
+
+    async << app->passNotificationToAI("Hello").onProcessed;
+    while (async.size() > 0) {
+        loop.iteration();
+    }
+
+    for (const auto& ev : spy.capturedEvents) {
+        EXPECT_FALSE(ev.toolName.empty()) << "ToolCallEvent must have a non-empty toolName";
+    }
+}
+
+// ============================================================================
+// toolCallFired is NOT emitted when a tool call fails (throws)
+// ============================================================================
+TEST_F(PrometheusUnitTest, ToolCallFiredNotEmittedOnToolException) {
+    AEventLoop loop;
+    IEventLoop::Handle h(&loop);
+    AAsyncHolder async;
+
+    auto openAI = _cast<IOpenAIChat>(_new<PrometheusOpenAIMock>());
+    // LLM calls "unknown_tool" (not registered) -> handler is not found, no onAfterToolCall
+    EXPECT_CALL(*static_cast<PrometheusOpenAIMock*>(openAI.get()), chat(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(makeToolCallResponse("unknown_tool")))
+        .WillOnce(::testing::Return(makeWaitResponse()));
+
+    class ThrowingHarness : public PrometheusTestHarness {
+    public:
+        explicit ThrowingHarness(_<IOpenAIChat> ai) : PrometheusTestHarness(std::move(ai)) {}
+    protected:
+        void updateTools(OpenAITools& actions) override {
+            PrometheusTestHarness::updateTools(actions);
+            // Insert a tool that throws
+            actions.insert({
+                .name = "throwing_tool",
+                .description = "A tool that always throws",
+                .handler = [](OpenAITools::Ctx) -> AFuture<AString> {
+                    throw AException("intentional test failure");
+                    co_return "";
+                },
+            });
+        }
+    };
+
+    auto app = _new<ThrowingHarness>(openAI);
+    SpyExporter spy;
+    spy.registerAppBase(*app);
+
+    async << app->passNotificationToAI("Hello").onProcessed;
+    while (async.size() > 0) {
+        loop.iteration();
+    }
+
+    // "unknown_tool" is not registered -> no handler -> onAfterToolCall not called
+    // "wait" IS registered and fires -> but it has no event since tool not in handled list for "unknown"
+    // Only "wait" will fire (if at all). But NOT for "unknown_tool".
+    for (const auto& ev : spy.capturedEvents) {
+        EXPECT_NE(ev.toolName, "unknown_tool")
+            << "toolCallFired should NOT be emitted for an unregistered tool";
+    }
+}
+
+// ============================================================================
+// toolCallFired breadcrumbLabels snapshot matches metricBreadcumbs at dispatch time
+// ============================================================================
+TEST_F(PrometheusUnitTest, ToolCallFiredBreadcrumbLabelsSnapshot) {
+    AEventLoop loop;
+    IEventLoop::Handle h(&loop);
+    AAsyncHolder async;
+
+    auto openAI = _cast<IOpenAIChat>(_new<PrometheusOpenAIMock>());
+    EXPECT_CALL(*static_cast<PrometheusOpenAIMock*>(openAI.get()), chat(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(makeMyToolResponse()))
+        .WillOnce(::testing::Return(makeWaitResponse()));
+
+    auto app = _new<PrometheusTestHarness>(openAI);
+
+    // Set a breadcrumb before processing
+    MetricsBreadcumbs::Point point(app->metricBreadcumbs(), "chat", "test_chat");
+
+    SpyExporter spy;
+    spy.registerAppBase(*app);
+
+    async << app->passNotificationToAI("Hello").onProcessed;
+    while (async.size() > 0) {
+        loop.iteration();
+    }
+
+    ASSERT_EQ(spy.capturedEvents.size(), 1);
+
+    auto& event = spy.capturedEvents[0];
+
+    // breadcrumbLabels should contain the "chat" key set above
+    EXPECT_TRUE(event.breadcrumbLabels.contains("chat"));
+    EXPECT_EQ(event.breadcrumbLabels["chat"], "test_chat");
+}
+
+// ============================================================================
+// toolCallFired carries lastOpenedChatLastMessageTime when set
+// ============================================================================
+TEST_F(PrometheusUnitTest, ToolCallFiredlastOpenedChatLastMessageTime) {
+    AEventLoop loop;
+    IEventLoop::Handle h(&loop);
+    AAsyncHolder async;
+
+    auto openAI = _cast<IOpenAIChat>(_new<PrometheusOpenAIMock>());
+    EXPECT_CALL(*static_cast<PrometheusOpenAIMock*>(openAI.get()), chat(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(makeMyToolResponse()))
+        .WillOnce(::testing::Return(makeWaitResponse()));
+
+    // A harness that populates lastOpenedChatLastMessageTime (mirrors main.cpp's App::updateTools)
+    class TimedHarness : public PrometheusTestHarness {
+    public:
+        explicit TimedHarness(_<IOpenAIChat> ai) : PrometheusTestHarness(std::move(ai)) {}
+    protected:
+        void updateTools(OpenAITools& actions) override {
+            PrometheusTestHarness::updateTools(actions);
+            actions.insert({
+                .name = "my_tool",
+                .description = "Test tool",
+                .handler = [](OpenAITools::Ctx) -> AFuture<AString> { co_return "ok"; },
+            });
+            actions.insert({
+                .name = "wait",
+                .description = "Wait",
+                .handler = [](OpenAITools::Ctx) -> AFuture<AString> { co_return "Waiting"; },
+            });
+        }
+    };
+
+    auto app = _new<TimedHarness>(openAI);
+    SpyExporter spy;
+    spy.registerAppBase(*app);
+
+    async << app->passNotificationToAI("Hello").onProcessed;
+    while (async.size() > 0) {
+        loop.iteration();
+    }
+
+    auto it = std::find_if(spy.capturedEvents.begin(), spy.capturedEvents.end(), [](const AppBase::ToolCallEvent& ev) {
+        return ev.toolName == "my_tool";
+    });
+    ASSERT_NE(it, spy.capturedEvents.end());
+
+    // lastOpenedChatLastMessageTime must be set and ≥ 42s (the simulated delay)
+    ASSERT_TRUE(it->lastOpenedChatLastMessageTime.hasValue());
+
+    // response time is hardcoded to 42s in this unit test.
+    // since it measures against time of taken action, there's a race condition, which may cause to alter the hardcoded
+    // value to 43s, 44s, etc. let's use EXPECT_NEAR instead of EXPECT_EQ.
+    EXPECT_NEAR(it->lastOpenedChatLastMessageTime->count(), 42, 5);
+}
+
+// ============================================================================
+// SpyExporter captures events from multiple tool calls in the same session
+// ============================================================================
+TEST_F(PrometheusUnitTest, MultipleToolCallsAllCaptured) {
+    AEventLoop loop;
+    IEventLoop::Handle h(&loop);
+    AAsyncHolder async;
+
+    auto openAI = _cast<IOpenAIChat>(_new<PrometheusOpenAIMock>());
+    // Two separate notifications, each dispatching my_tool then wait
+    EXPECT_CALL(*static_cast<PrometheusOpenAIMock*>(openAI.get()), chat(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(makeMyToolResponse()))
+        .WillOnce(::testing::Return(makeWaitResponse()))
+        .WillOnce(::testing::Return(makeMyToolResponse()))
+        .WillOnce(::testing::Return(makeWaitResponse()));
+
+    auto app = _new<PrometheusTestHarness>(openAI);
+    SpyExporter spy;
+    spy.registerAppBase(*app);
+
+    async << app->passNotificationToAI("First").onProcessed;
+    while (async.size() > 0) {
+        loop.iteration();
+    }
+
+    async << app->passNotificationToAI("Second").onProcessed;
+    while (async.size() > 0) {
+        loop.iteration();
+    }
+
+    EXPECT_TRUE(ranges::all_of(spy.capturedEvents, [](const AppBase::ToolCallEvent& ev) {
+        return ev.toolName == "my_tool";
+    })) << "we expect my_tool to be reported only";
+    EXPECT_EQ(spy.capturedEvents.size(), 2) << "my_tool should have fired exactly twice (once per notification)";
+}
+
+// ============================================================================
+// registerAppBase is safe to call before any tool calls happen
+// ============================================================================
+TEST_F(PrometheusUnitTest, RegisterAppBaseSafeWithNoToolCalls) {
+    auto openAI = _cast<IOpenAIChat>(_new<PrometheusOpenAIMock>());
+    auto app = _new<PrometheusTestHarness>(openAI);
+
+    SpyExporter spy;
+    // Should not crash even if no notifications/tool-calls ever happen
+    EXPECT_NO_THROW(spy.registerAppBase(*app));
+    EXPECT_TRUE(spy.capturedEvents.empty());
+    AThread::processMessages();
+}

--- a/tests/TelegramIntegrationTests.cpp
+++ b/tests/TelegramIntegrationTests.cpp
@@ -1,10 +1,26 @@
 #include "config.h"
 #include <gmock/gmock.h>
+#include <range/v3/all.hpp>
 
 #include "AUI/Thread/AAsyncHolder.h"
 #include "AUI/Thread/AEventLoop.h"
+#include "llmui/audio.h"
+#include "llmui/telegram.h"
 #include "telegram/TelegramClientImpl.h"
 #include "util/post_message.h"
+
+// ---------------------------------------------------------------------------
+// Mock IOpenAIChat
+// ---------------------------------------------------------------------------
+class OpenAIMock : public IOpenAIChat {
+public:
+    MOCK_METHOD(AFuture<Response>, chat, (Params params, AVector<Message> messages), (override));
+
+    ::_<StreamingResponse> chatStreaming(Params params, AVector<Message> messages) override {
+        return nullptr;
+    }
+    MOCK_METHOD(AFuture<std::valarray<double>>, embedding, (Params params, AString input), (override));
+};
 
 TEST(TelegramIntegration, PostMessage) {
     AEventLoop loop;
@@ -35,4 +51,41 @@ TEST(TelegramIntegration, PostMessage) {
     loop.loop();
 }
 
+
+TEST(TelegramIntegration, GiftsFormatting) {
+    // telegram gifts have weird formatting
+    AEventLoop loop;
+    IEventLoop::Handle h(&loop);
+    auto telegram = _new<TelegramClientImpl>();
+    AThread::processMessages();
+    AAsyncHolder async;
+    async << [](_<ITelegramClient> telegram) -> AFuture<> {
+        try {
+            OpenAIMock openAI;
+            static constexpr auto CHAT_ID = 5979666573;
+            static constexpr auto MESSAGE_ID = 52919533568;
+            co_await telegram->waitForConnection();
+            auto messages = co_await telegram->sendQueryWithResult(ITelegramClient::toPtr(td::td_api::getChatHistory(CHAT_ID, MESSAGE_ID, -1, 10, true)));
+            auto giftMessage = ranges::find(messages->messages_, MESSAGE_ID, [](const td::td_api::object_ptr<td::td_api::message>& m) {
+                return m->id_;
+            });
+            EXPECT_FALSE(giftMessage == messages->messages_.end());
+            auto formatting = co_await llmui::formatChatHistoryMessage(*telegram, **giftMessage, *co_await telegram->sendQueryWithResult(ITelegramClient::toPtr(td::td_api::getChat(CHAT_ID))), openAI, {});
+            static constexpr auto EXPECTED_FORMATTING = R"XYI(<message message_id="52919533568" date="2026-05-21 06:38:08" sender="Итальянский Премьер (@dio5556)">
+<gift cost="25 stars" text="куни куни😊😊😊" emoji="🌹" description>
+This media type is not supported
+</gift cost="25 stars" text="куни куни😊😊😊" emoji="🌹">[gift]
+</message message_id="52919533568" date="2026-05-21 06:38:08" sender="Итальянский Премьер (@dio5556)">)XYI";
+            EXPECT_EQ(formatting, EXPECTED_FORMATTING) << "Got formatting:\n" << formatting;
+        } catch (const AException& e) {
+            ALogger::err("TelegramTests") << "Unhandled exception: " << e;
+            ADD_FAILURE() << "Unhandled exception";
+        }
+        co_return;
+    }(telegram);
+
+    while (async.size() > 0) {
+        loop.iteration();
+    }
+}
 


### PR DESCRIPTION
1. Improved LLM token usage panels
<img width="3299" height="1888" alt="Screenshot From 2026-05-24 20-48-03" src="https://github.com/user-attachments/assets/f945369f-436b-4cc8-8ad8-571eec978160" />

2. Added response time heatmap.
3. Added token usage per tool and per user heatmaps.
<img width="3247" height="1265" alt="image" src="https://github.com/user-attachments/assets/5b801e10-6033-4c3b-acd7-3caddd360282" />

5. Added a new panel (+code) to track the following events: bot writes a follow up message depsite the bot have written to the user already and they didn't reply. This shows engagement to the user and now we can track bot's attempts to push the dialog forward.

<img width="3263" height="1433" alt="image" src="https://github.com/user-attachments/assets/6d850241-3f25-4fb4-9bb0-6698aeb6ca08" />
