### PR TITLE
feat(tools): add forward_message tool

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include "tools/stickers.h"
 #include "tools/send_telegram_message.h"
 #include "tools/edit_message_text.h"
+#include "tools/forward_message.h"
 #include "ui/debug/KuniDebugWindow.h"
 #include "util/is_accessible_from_lockdown.h"
 #include "util/post_message.h"
@@ -616,12 +617,19 @@ Pay close attention to these messages. Acquire context from them. You can't resp
 (#send_telegram_message tool is not available). Instead, do what you usually do when reading newsletters: reflect and reason
 on them.
 Some channels have reactions enabled. In that case, you can sometimes react with #react_with_emoji to express your feelings about a message, but you can't send a full reply.
+
+Forwarding posts:
+If you find a post genuinely interesting, funny, or relevant to someone you know — you can forward it to another chat
+using #forward_message. Be selective: only forward posts that are truly worth sharing. You can add a short comment
+expressing your reaction. Use #get_telegram_chats to find the destination chat_id if needed.
+Do NOT forward ads, sponsored posts, or low-value content.
 </instructions>
 )"_format(chat->title_);
                     tools = OpenAITools {
                         tools::reactWithEmoji(telegram(), chat),
+                        tools::forwardMessage(telegram(), chat),
                     };
-                    co_return result;   // no tools for channels
+                    co_return result;   // no send_telegram_message for channels
                 }
             }
         }
@@ -634,6 +642,7 @@ Some channels have reactions enabled. In that case, you can sometimes react with
             tools::reactWithEmoji(telegram(), chat),
             tools::removeMessage(telegram(), chat),
             tools::editMessageText(telegram(), chat),
+            tools::forwardMessage(telegram(), chat),
         };
 
         if constexpr (config::CAPABILITY_USE_STICKERS) {

--- a/src/tools/forward_message.cpp
+++ b/src/tools/forward_message.cpp
@@ -1,0 +1,79 @@
+//
+// Created by kuni on 6/24/26.
+//
+
+#include "forward_message.h"
+
+#include "util/json_utils.h"
+
+static constexpr auto LOG_TAG = "tools::forwardMessage";
+
+OpenAITools::Tool tools::forwardMessage(_<ITelegramClient> telegram, _<td::td_api::chat> fromChat) {
+    return {
+        .name = "forward_message",
+        .description = "Forwards one or more messages from the currently opened channel to another chat (e.g., to a friend, "
+                       "a group, or to Saved Messages). Use this when you find a post in a channel interesting "
+                       "enough to share. You can optionally add a comment that will be sent as a separate message "
+                       "after the forward.",
+        .parameters = {
+            .properties = {
+                {"message_ids", {
+                    .type = "array",
+                    .description = "IDs of the messages to forward. Taken from message_id attributes in <message> tags. "
+                                   "Pass a single-element array to forward just one message.",
+                }},
+                {"to_chat_id", {
+                    .type = "integer",
+                    .description = "ID of the destination chat. Use #get_telegram_chats to find chat IDs. "
+                                   "Use your own chat ID (Saved Messages) to forward to yourself.",
+                }},
+                {"comment", {
+                    .type = "string",
+                    .description = "Optional comment to send after the forwarded message. "
+                                   "Express your reaction, thoughts, or why you found this interesting.",
+                }},
+            },
+            .required = {"message_ids", "to_chat_id"},
+        },
+        .handler = [telegram, fromChat](OpenAITools::Ctx ctx) -> AFuture<AString> {
+            auto toChatId  = util::jsonAsLongInt(ctx.args["to_chat_id"]).valueOrException("to_chat_id integer required");
+            auto comment   = ctx.args["comment"].asStringOpt();
+
+            auto& idsJson = ctx.args["message_ids"];
+            if (!idsJson.isArray()) throw AException("message_ids must be an array");
+            std::vector<std::int64_t> messageIds;
+            for (const auto& v : idsJson.asArray()) {
+                messageIds.push_back(util::jsonAsLongInt(v).valueOrException("message_ids must contain integers"));
+            }
+            if (messageIds.empty()) throw AException("message_ids must not be empty");
+
+            auto messageCount = messageIds.size();
+
+            ALogger::info(LOG_TAG) << "Forwarding " << messageCount << " message(s)"
+                                   << " from chat " << fromChat->id_
+                                   << " to chat " << toChatId;
+
+            auto fwd = td::td_api::make_object<td::td_api::forwardMessages>();
+            fwd->chat_id_      = toChatId;
+            fwd->from_chat_id_ = fromChat->id_;
+            fwd->message_ids_  = std::move(messageIds);
+            fwd->send_copy_    = false;
+            fwd->remove_caption_ = false;
+
+            co_await telegram->sendQueryWithResult(std::move(fwd));
+
+            if (comment && !comment->empty()) {
+                auto sendMsg = td::td_api::make_object<td::td_api::sendMessage>();
+                sendMsg->chat_id_ = toChatId;
+                auto content = td::td_api::make_object<td::td_api::inputMessageText>();
+                auto formattedText = td::td_api::make_object<td::td_api::formattedText>();
+                formattedText->text_ = comment->toStdString();
+                content->text_ = std::move(formattedText);
+                sendMsg->input_message_content_ = std::move(content);
+                co_await telegram->sendQueryWithResult(std::move(sendMsg));
+            }
+
+            co_return "Forwarded {} message(s) successfully to chat_id={}"_format(messageCount, toChatId);
+        },
+    };
+}

--- a/src/tools/forward_message.h
+++ b/src/tools/forward_message.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "OpenAITools.h"
+#include "telegram/ITelegramClient.h"
+
+namespace tools {
+/**
+ * @brief Tool that forwards a message from the currently opened chat to another chat.
+ *
+ * Useful when reading Telegram channels — Kuni can forward interesting posts to other chats
+ * (e.g., to a friend, a group, or to herself as a saved message).
+ *
+ * @param telegram  The Telegram client.
+ * @param fromChat  The chat currently opened (source of the message).
+ */
+OpenAITools::Tool forwardMessage(_<ITelegramClient> telegram, _<td::td_api::chat> fromChat);
+}


### PR DESCRIPTION
## What

New `forward_message` tool that allows forwarding messages from a channel to any chat.

## Changes

- `src/tools/forward_message.cpp/h` — new tool implementation (by kuni 🐱)
- `src/main.cpp` — integrated into channel and regular chat tool sets, added prompt instructions

## Details

- supports forwarding multiple message IDs in one call
- optional comment sent after the forwarded messages
- model is instructed to be selective (no ads/spam)
- fix: save `messageIds.size()` before `std::move` to avoid use-after-move in return string