### PR TITLE
feat: add telegram_enabled toggle for standalone proxy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Open it and populate at minimum the `[general]` section:
 ```toml
 [general]
 character_name = "Kuni"          # your character's name
+telegram_enabled = true          # set to false to run as a standalone proxy without Telegram
 character_nickname = "@kunii_chan"
 papik_name = "Alex2772"          # your nickname — the instance owner
 papik_chat_id = 625207005        # your Telegram user ID
@@ -392,6 +393,10 @@ Client  ──POST /v1/chat/completions──►  Proxy
 ### Configuration
 
 Enable `PROXY_ENABLED` in config.
+
+#### Standalone mode (No Telegram)
+
+If you just want to use Kuni as a local RAG proxy for your IDE without dealing with Telegram accounts, set `telegram_enabled = false` in `config.toml`. Kuni will bypass TDLib initialization and spin up the proxy server directly on port 10434. 
 
 #### VS Code GitHub Copilot.
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -134,6 +134,11 @@ static const std::unordered_map<AStringView, AStringView> CONFIG_COMMENTS = {
       "https://habr.com/ru/articles/923168/",
     },
     {
+      "general.telegram_enabled",
+      "Whether to enable the Telegram bot. If set to false, Kuni will run in standalone mode\n"
+      "(useful if you only want to use the proxy server without a Telegram account).",
+    },
+    {
       "general.telegram_api_hash",
       "tdlib API hash, acquired on the same page as telegram_api_id.",
     },
@@ -526,8 +531,9 @@ static Config load(bool saveBack = false) {
 
 #ifndef AUI_TESTS_MODULE
     // validation
-    {
-        const auto& value = toml["general"]["telegram_api_id"];
+    if (out.telegramEnabled) {
+        {
+            const auto& value = toml["general"]["telegram_api_id"];
         if (value.as_integer() == 0) {
             ALogger::err(LOG_TAG) << toml::format_error(
                 (toml::make_error_info("general.telegram_api_id should be populated", value, "the actual value is 0")));
@@ -541,6 +547,7 @@ static Config load(bool saveBack = false) {
                 "general.telegram_api_hash should be populated", value, "the actual string is empty")));
             std::exit(-1);
         }
+    }
     }
 #endif
     ALogger::info(LOG_TAG) << CONFIG_TOML << " loaded";

--- a/src/config.h
+++ b/src/config.h
@@ -12,6 +12,7 @@
   X(std::int64_t, papikChatId, 625207005,"general.papik_chat_id") \
   X(std::int64_t, telegramApiId, 0,"general.telegram_api_id") \
   X(AString,telegramApiHash, "", "general.telegram_api_hash") \
+  X(bool, telegramEnabled, true, "general.telegram_enabled") \
   X(EndpointAndModel, llm, (EndpointAndModel{.endpoint={"http://localhost:11434/v1/"},.model="deepseek-v4-flash"}), "general.llm") \
   X(EndpointAndModel, embedding, (EndpointAndModel{.endpoint={"http://localhost:11434/v1/"},.model="qwen3-embedding"}), "general.embedding") \
   X(::Config::LockdownMode, lockdown, ::Config::LockdownMode::PAPIK_ONLY, "general.lockdown") \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -629,81 +629,87 @@ AUI_ENTRY {
     }
 
     using namespace std::chrono_literals;
-    auto telegram = _new<TelegramClientImpl>();
 
     AAsyncHolder async;
-    async << [](_<ITelegramClient> telegram) -> AFuture<> {
-        ALogger::info(LOG_TAG) << "Waiting for Telegram network...";
-        co_await telegram->waitForConnection();
-        switch (config().lockdown) {
-            case Config::LockdownMode::NONE:
-                break;
-            case Config::LockdownMode::CONTACTS_ONLY:
-                ALogger::info(LOG_TAG) << "Lockdown mode is enabled (config.toml lockdown). Kuni can only chat with "
-                                          "her contacts.";
-                break;
-            case Config::LockdownMode::PAPIK_ONLY:
-                ALogger::info(LOG_TAG) << "Lockdown mode is enabled (config.toml lockdown). Kuni can only open chat with ID {} (PAPIK_CHAT_ID)."_format(
-                    config().papikChatId);
-                break;
-        }
-        // app->actProactively(); // for tests
-    }(telegram);
-
     _<prometheus::IExporter> prometheus;
     _<App> app;
     _<proxy_server::IProxyServer> proxyServer;
     _<proxy_server::ContextBridge> contextBridge;
-    AObject::connect(telegram->loggedIn, telegram, [&] {
-        auto openAI = _new<OpenAIChatMeasurable>(std::make_unique<OpenAIChatImpl>());
-        app = _new<App>(telegram, openAI);
 
+    if (config().telegramEnabled) {
+        auto telegram = _new<TelegramClientImpl>();
+        async << [](_<ITelegramClient> telegram) -> AFuture<> {
+            ALogger::info(LOG_TAG) << "Waiting for Telegram network...";
+            co_await telegram->waitForConnection();
+            switch (config().lockdown) {
+                case Config::LockdownMode::NONE: break;
+                case Config::LockdownMode::CONTACTS_ONLY:
+                    ALogger::info(LOG_TAG) << "Lockdown mode is enabled (config.toml lockdown). Kuni can only chat with her contacts."; break;
+                case Config::LockdownMode::PAPIK_ONLY:
+                    ALogger::info(LOG_TAG) << "Lockdown mode is enabled (config.toml lockdown). Kuni can only open chat with ID {} (PAPIK_CHAT_ID)."_format(config().papikChatId); break;
+            }
+        }(telegram);
+
+        AObject::connect(telegram->loggedIn, telegram, [&] {
+            auto openAI = _new<OpenAIChatMeasurable>(std::make_unique<OpenAIChatImpl>());
+            app = _new<App>(telegram, openAI);
+
+            if (config().proxyEnabled) {
+                auto diary = std::make_shared<Diary>(Diary::Init { .diaryDir = "data/diary", .openAI = openAI });
+                proxyServer = proxy_server::init({
+                  .upstreamEndpoint = config().llm.endpoint,
+                  .port = 10434,
+                  .toolsFactory = [openAI, diary](IOpenAIChat::Session ctx) {
+                      return OpenAITools { tools::ask([ctx = std::move(ctx)] { return ctx.empty() ? AString {} : AString(ctx.last().content); }, openAI, *diary) };
+                  },
+                });
+                contextBridge = _new<proxy_server::ContextBridge>(proxy_server::ContextBridge::Config { .endpoint = config().llm.endpoint, .diary = diary });
+                AObject::connect(proxyServer->sentRequestToLLM, AUI_SLOT(contextBridge)::collectRequestToLLM);
+                app->chatHistoryMessageProcessors << contextBridge;
+            }
+            prometheus = prometheus::setup(app->metricBreadcumbs());
+            prometheus->registerOpenAI(*openAI);
+            prometheus->registerAppBase(*app);
+            _new<AThread>([] {
+                ALogger::info(LOG_TAG) << "Bot is up and running. Press enter to shutdown gracefully.";
+                std::cin.get();
+                ALogger::info(LOG_TAG) << "Bot is shutting down. Please give some time to dump remaining context";
+                gEventLoop.stop();
+            })->start();
+        });
+    } else {
+        auto openAI = _new<OpenAIChatMeasurable>(std::make_unique<OpenAIChatImpl>());
         if (config().proxyEnabled) {
             auto diary = std::make_shared<Diary>(Diary::Init { .diaryDir = "data/diary", .openAI = openAI });
             proxyServer = proxy_server::init({
               .upstreamEndpoint = config().llm.endpoint,
               .port = 10434,
-              .toolsFactory =
-                  [openAI, diary](IOpenAIChat::Session ctx) {
-                      // Create the tools directly without using an initializer list
-                      return OpenAITools {
-                          tools::ask(
-                              [ctx = std::move(ctx)] { return ctx.empty() ? AString {} : AString(ctx.last().content); }, openAI, *diary),
-                      };
-                  },
+              .toolsFactory = [openAI, diary](IOpenAIChat::Session ctx) {
+                  return OpenAITools { tools::ask([ctx = std::move(ctx)] { return ctx.empty() ? AString {} : AString(ctx.last().content); }, openAI, *diary) };
+              },
             });
-            contextBridge = _new<proxy_server::ContextBridge>(proxy_server::ContextBridge::Config {
-              .endpoint = config().llm.endpoint,
-              .diary = diary,
-            });
+            contextBridge = _new<proxy_server::ContextBridge>(proxy_server::ContextBridge::Config { .endpoint = config().llm.endpoint, .diary = diary });
             AObject::connect(proxyServer->sentRequestToLLM, AUI_SLOT(contextBridge)::collectRequestToLLM);
-            app->chatHistoryMessageProcessors << contextBridge;
+            ALogger::info(LOG_TAG) << "Proxy server started standalone (No Telegram)!";
         }
-        prometheus = prometheus::setup(app->metricBreadcumbs());
+        
+        auto dummyBreadcrumbs = _new<MetricsBreadcumbs>();
+        prometheus = prometheus::setup(dummyBreadcrumbs);
         prometheus->registerOpenAI(*openAI);
-        prometheus->registerAppBase(*app);
         _new<AThread>([] {
             ALogger::info(LOG_TAG) << "Bot is up and running. Press enter to shutdown gracefully.";
             std::cin.get();
             ALogger::info(LOG_TAG) << "Bot is shutting down. Please give some time to dump remaining context";
             gEventLoop.stop();
         })->start();
-    });
+    }
 
     IEventLoop::Handle h(&gEventLoop);
     gEventLoop.loop();
 
-    if (app) {
-        async << app->diaryDumpMessages();
-    }
+    if (app) { async << app->diaryDumpMessages(); }
+    if (contextBridge) { async << contextBridge->collectAndSaveSessionsNotNewerThan(std::chrono::system_clock::now()); }
 
-    if (contextBridge) {
-        async << contextBridge->collectAndSaveSessionsNotNewerThan(std::chrono::system_clock::now());
-    }
-
-    while (!async.empty()) {
-        gEventLoop.iteration();
-    }
-
+    while (!async.empty()) { gEventLoop.iteration(); }
     return 0;
 }


### PR DESCRIPTION
### English
This PR introduces a `general.telegram_enabled` toggle in `config.toml`.

By setting `telegram_enabled = false`, Kuni skips TDLib initialization completely and runs strictly in standalone mode. 

This is highly useful for users who want to run the built-in LLM proxy server and diary RAG (`ContextBridge`) locally for their IDEs (like VS Code Copilot or Cline), without needing to link a Telegram account.

**Changes:**
- Added `telegramEnabled` config parameter.
- Bypassed `telegram_api_id` / `telegram_api_hash` validation when the toggle is disabled.
- Refactored `main.cpp` to conditionally instantiate `TelegramClientImpl` and the main `App` class.
- Updated `README.md` to reflect the standalone proxy mode.

---

### Русский
В этом PR добавлен переключатель `general.telegram_enabled` в `config.toml`.

Если установить `telegram_enabled = false`, Kuni полностью пропускает инициализацию TDLib и запускается строго в автономном режиме.

Это очень полезно для тех, кто хочет использовать встроенный LLM прокси-сервер и RAG-дневник (`ContextBridge`) локально для своих IDE (например, VS Code Copilot или Cline), без необходимости привязывать аккаунт Telegram.

**Изменения:**
- Добавлен параметр `telegramEnabled` в конфиг.
- Отключена валидация `telegram_api_id` / `telegram_api_hash`, если Telegram выключен.
- Изменен `main.cpp` для условной инициализации `TelegramClientImpl` и класса `App`.
- Обновлен `README.md` с описанием автономного режима прокси.