### PR TITLE
fix: handle "usage": null in streaming chunks (OpenAI-compatible providers)

### DIFF
--- a/src/IOpenAIChat.cpp
+++ b/src/IOpenAIChat.cpp
@@ -83,6 +83,11 @@ AFuture<IOpenAIChat::Response> IOpenAIChat::chat(Params params, IOpenAIChat::Ses
 
 void AJsonConv<IOpenAIChat::Response::Usage, void>::fromJson(const AJson& v, IOpenAIChat::Response::Usage& dst) {
     aui::zero(dst);
+    if (!v.isObject()) {
+        // OpenAI-compatible endpoints (e.g. gpt-4o-mini) send `"usage": null` in every streaming chunk but
+        // the last one. The OPTIONAL field flag only covers a missing key, not an explicit null.
+        return;
+    }
     dst.prompt_tokens = v["prompt_tokens"].asLongIntOpt().valueOr(0);
     dst.completion_tokens = v["completion_tokens"].asLongIntOpt().valueOr(0);
     dst.total_tokens = v["total_tokens"].asLongIntOpt().valueOr(0);


### PR DESCRIPTION
### Problem

OpenAI-compatible endpoints — `gpt-4o-mini` and cloud aggregators like OpenRouter / RouterAI — send `"usage": null` in every streaming chunk except the last one.

`AJsonConv<IOpenAIChat::Response::Usage>::fromJson` assumes a JSON object. The `OPTIONAL` field flag only covers a *missing* key, not an explicit `null`, so parsing threw mid-stream and crashed the app when using these backends.

### Fix

Guard against a non-object `usage` value and keep the zeroed usage in that case — the real totals still arrive in the final chunk.

5-line change, no behavior change for well-formed responses. Relevant to the `feat/openrouter` effort: this is one of the concrete compatibility issues aggregator backends hit.